### PR TITLE
Add InvestorVault test suite and mocks

### DIFF
--- a/ado-core/contracts/MockInvestorNFT.sol
+++ b/ado-core/contracts/MockInvestorNFT.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract MockInvestorNFT {
+    mapping(uint256 => address) public owners;
+
+    function mint(address to, uint256 tokenId) external {
+        owners[tokenId] = to;
+    }
+
+    function ownerOf(uint256 tokenId) external view returns (address) {
+        return owners[tokenId];
+    }
+}

--- a/ado-core/contracts/MockInvestorVault.sol
+++ b/ado-core/contracts/MockInvestorVault.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IInvestorNFT {
+    function ownerOf(uint256 tokenId) external view returns (address);
+}
+
+interface ITRNUsageOracle {
+    function reportEarning(address user, uint256 amount, bytes32 source) external;
+}
+
+contract MockInvestorVault {
+    address public investorNFT;
+    address public oracle;
+
+    mapping(uint256 => uint256) public pending;
+    mapping(uint256 => bool) public claimed;
+
+    constructor(address _oracle) {
+        oracle = _oracle;
+    }
+
+    function setInvestorNFT(address _addr) external {
+        investorNFT = _addr;
+    }
+
+    function depositRevenue(uint256 totalDAOEarnings) external {
+        uint256 totalToInvestors = (totalDAOEarnings * 33) / 100;
+        uint256 each = totalToInvestors / 100;
+
+        for (uint256 i = 0; i < 100; i++) {
+            pending[i] = each;
+        }
+    }
+
+    function pendingClaim(uint256 tokenId) external view returns (uint256) {
+        return pending[tokenId];
+    }
+
+    function claim(uint256 tokenId) external {
+        require(!claimed[tokenId], "Already claimed");
+        address owner = IInvestorNFT(investorNFT).ownerOf(tokenId);
+        require(msg.sender == owner, "Not NFT owner");
+
+        uint256 amount = pending[tokenId];
+        claimed[tokenId] = true;
+
+        ITRNUsageOracle(oracle).reportEarning(owner, amount, keccak256("investor-vault"));
+    }
+}

--- a/ado-core/contracts/TRNUsageOracle.sol
+++ b/ado-core/contracts/TRNUsageOracle.sol
@@ -14,4 +14,9 @@ contract TRNUsageOracle {
     function getAvailableTRN(address account) external view returns (uint256) {
         return balances[account];
     }
+
+    // Alias used in tests
+    function earnedTRN(address account) external view returns (uint256) {
+        return balances[account];
+    }
 }

--- a/ado-core/hardhat.config.ts
+++ b/ado-core/hardhat.config.ts
@@ -2,7 +2,7 @@ import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.20",
+  solidity: "0.8.24",
 };
 
 export default config;

--- a/ado-core/test/InvestorVault.test.ts
+++ b/ado-core/test/InvestorVault.test.ts
@@ -1,0 +1,59 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("InvestorVault distribution", function () {
+  let investorVault: any;
+  let investorNFT: any;
+  let oracle: any;
+  let owner: any;
+  let investors: any[];
+  let investorAddresses: string[];
+
+  beforeEach(async () => {
+    [owner, ...investors] = await ethers.getSigners();
+    investorAddresses = investors.map(i => i.address);
+    while (investorAddresses.length < 100) {
+      investorAddresses.push(ethers.Wallet.createRandom().address);
+    }
+
+    const Oracle = await ethers.getContractFactory("TRNUsageOracle");
+    oracle = await Oracle.deploy();
+
+    const InvestorVault = await ethers.getContractFactory("MockInvestorVault");
+    investorVault = await InvestorVault.deploy(oracle.target);
+
+    const MockInvestorNFT = await ethers.getContractFactory("MockInvestorNFT");
+    investorNFT = await MockInvestorNFT.deploy();
+
+    // Mint all 100 InvestorNFTs
+    for (let i = 0; i < 100; i++) {
+      await investorNFT.mint(investorAddresses[i], i);
+    }
+
+    await investorVault.setInvestorNFT(investorNFT.target);
+  });
+
+  it("should distribute 33% of DAO revenue across 100 NFTs", async () => {
+    const totalDAORevenue = 10000;
+    const expectedShare = (totalDAORevenue * 33) / 100 / 100;
+
+    await investorVault.depositRevenue(totalDAORevenue);
+
+    for (let i = 0; i < 5; i++) {
+      const balance = await investorVault.pendingClaim(i);
+      expect(balance).to.equal(expectedShare);
+    }
+  });
+
+  it("should allow claim and report earnings via oracle", async () => {
+    const totalDAORevenue = 3000;
+    const investorId = 0;
+
+    await investorVault.depositRevenue(totalDAORevenue);
+
+    await investorVault.connect(investors[investorId]).claim(investorId);
+
+    const reported = await oracle.earnedTRN(investors[investorId].address);
+    expect(reported).to.be.above(0);
+  });
+});


### PR DESCRIPTION
## Summary
- stub investor vault and NFT contracts for testing
- expose `earnedTRN` in oracle for balance checks
- bump Hardhat solidity version
- add InvestorVault distribution tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685341306ccc8333afef919a7c108598