### PR TITLE
Add ContributorVault contract and tests

### DIFF
--- a/ado-core/contracts/MockContributorNFT.sol
+++ b/ado-core/contracts/MockContributorNFT.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract MockContributorNFT {
+    mapping(uint256 => address) public owners;
+
+    function mint(address to, uint256 tokenId) external {
+        owners[tokenId] = to;
+    }
+
+    function ownerOf(uint256 tokenId) external view returns (address) {
+        return owners[tokenId];
+    }
+}

--- a/ado-core/contracts/MockContributorVault.sol
+++ b/ado-core/contracts/MockContributorVault.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IContributorNFT {
+    function ownerOf(uint256 tokenId) external view returns (address);
+}
+
+interface ITRNUsageOracle {
+    function reportEarning(address user, uint256 amount, bytes32 source) external;
+}
+
+contract MockContributorVault {
+    address public contributorNFT;
+    address public oracle;
+    address public beneficiary;
+
+    struct Allocation {
+        uint256 amount;
+        uint256 assignedAt;
+        bool claimed;
+    }
+
+    mapping(uint256 => Allocation) public allocations;
+
+    constructor(address _oracle) {
+        oracle = _oracle;
+    }
+
+    function setContributorNFT(address _addr) external {
+        contributorNFT = _addr;
+    }
+
+    function setBeneficiary(address _addr) external {
+        beneficiary = _addr;
+    }
+
+    function assign(uint256 tokenId, uint256 amount) external {
+        allocations[tokenId] = Allocation(amount, block.timestamp, false);
+    }
+
+    function pendingClaim(uint256 tokenId) external view returns (uint256) {
+        Allocation memory a = allocations[tokenId];
+        if (a.claimed) return 0;
+        return a.amount;
+    }
+
+    function claim(uint256 tokenId) external {
+        Allocation storage a = allocations[tokenId];
+        require(!a.claimed, "Already claimed");
+        require(IContributorNFT(contributorNFT).ownerOf(tokenId) == msg.sender, "Not NFT owner");
+
+        a.claimed = true;
+        ITRNUsageOracle(oracle).reportEarning(msg.sender, a.amount, keccak256("contributor-vault"));
+    }
+
+    function reclaim(uint256 tokenId) external {
+        Allocation storage a = allocations[tokenId];
+        require(!a.claimed, "Already claimed");
+        require(block.timestamp > a.assignedAt + 90 days, "Too early");
+
+        a.claimed = true;
+        ITRNUsageOracle(oracle).reportEarning(beneficiary, a.amount, keccak256("expired-contributor"));
+    }
+}

--- a/ado-core/test/ContributorVault.test.ts
+++ b/ado-core/test/ContributorVault.test.ts
@@ -1,0 +1,55 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("ContributorVault", function () {
+  let vault: any;
+  let nft: any;
+  let oracle: any;
+  let owner: any;
+  let contributors: any[];
+
+  beforeEach(async () => {
+    [owner, ...contributors] = await ethers.getSigners();
+
+    const Oracle = await ethers.getContractFactory("TRNUsageOracle");
+    oracle = await Oracle.deploy();
+
+    const NFT = await ethers.getContractFactory("MockContributorNFT");
+    nft = await NFT.deploy();
+
+    for (let i = 0; i < 5; i++) {
+      await nft.mint(contributors[i].address, i);
+    }
+
+    const Vault = await ethers.getContractFactory("MockContributorVault");
+    vault = await Vault.deploy(oracle.target);
+    await vault.setContributorNFT(nft.target);
+    await vault.setBeneficiary(owner.address);
+  });
+
+  it("should allow contributors to claim assigned TRN", async () => {
+    const payout = 750;
+    await vault.assign(0, payout);
+
+    const pending = await vault.pendingClaim(0);
+    expect(pending).to.equal(payout);
+
+    await vault.connect(contributors[0]).claim(0);
+
+    const earned = await oracle.earnedTRN(contributors[0].address);
+    expect(earned).to.equal(payout);
+  });
+
+  it("should redirect payout after deadline passes", async () => {
+    await vault.assign(1, 1000);
+
+    // simulate >90 days passing
+    await ethers.provider.send("evm_increaseTime", [91 * 86400]);
+    await ethers.provider.send("evm_mine");
+
+    await vault.reclaim(1);
+
+    const recovered = await oracle.earnedTRN(owner.address);
+    expect(recovered).to.equal(1000);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `MockContributorVault` contract with claim and reclaim logic
- add `MockContributorNFT` for testing
- create `ContributorVault.test.ts` to verify claim and reclaim behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685343a469688333b785d511ee328f24