### PR TITLE
Add DAO governance proposal test and contracts

### DIFF
--- a/ado-core/contracts/MockCouncilNFT.sol
+++ b/ado-core/contracts/MockCouncilNFT.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract MockCouncilNFT {
+    mapping(uint256 => address) public owners;
+
+    function mint(address to, uint256 tokenId) external {
+        owners[tokenId] = to;
+    }
+
+    function ownerOf(uint256 tokenId) external view returns (address) {
+        return owners[tokenId];
+    }
+
+    function balanceOf(address user) external view returns (uint256) {
+        uint256 count;
+        for (uint256 i = 0; i < 100; i++) {
+            if (owners[i] == user) count++;
+        }
+        return count;
+    }
+}

--- a/ado-core/contracts/MockProposalFactory.sol
+++ b/ado-core/contracts/MockProposalFactory.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface ICouncilNFT {
+    function balanceOf(address user) external view returns (uint256);
+}
+
+contract MockProposalFactory {
+    address public council;
+    address public master;
+    uint256 public nextId;
+
+    enum Status {Pending, PendingMasterApproval, Approved, Rejected}
+
+    struct Proposal {
+        string description;
+        uint256 yesVotes;
+        uint256 noVotes;
+        Status status;
+    }
+
+    mapping(uint256 => Proposal) public proposals;
+    mapping(uint256 => mapping(address => bool)) public voted;
+
+    constructor(address _council, address _master) {
+        council = _council;
+        master = _master;
+    }
+
+    function createProposal(string calldata desc, bytes calldata data) external returns (uint256) {
+        require(ICouncilNFT(council).balanceOf(msg.sender) > 0, "Not council");
+
+        proposals[nextId] = Proposal(desc, 0, 0, Status.Pending);
+        emit ProposalCreated(nextId, msg.sender, desc);
+        return nextId++;
+    }
+
+    function vote(uint256 id, bool support) external {
+        require(ICouncilNFT(council).balanceOf(msg.sender) > 0, "Not council");
+        require(!voted[id][msg.sender], "Already voted");
+
+        voted[id][msg.sender] = true;
+        if (support) {
+            proposals[id].yesVotes++;
+        } else {
+            proposals[id].noVotes++;
+        }
+
+        if (proposals[id].yesVotes >= 2) {
+            proposals[id].status = Status.PendingMasterApproval;
+        }
+    }
+
+    function finalizeProposal(uint256 id, bool approve) external {
+        require(msg.sender == master, "Only master");
+
+        if (approve) {
+            proposals[id].status = Status.Approved;
+        } else {
+            proposals[id].status = Status.Rejected;
+        }
+    }
+
+    function getProposalStatus(uint256 id) external view returns (string memory) {
+        Status s = proposals[id].status;
+        if (s == Status.Pending) return "Pending";
+        if (s == Status.PendingMasterApproval) return "PendingMasterApproval";
+        if (s == Status.Approved) return "Approved";
+        return "Rejected";
+    }
+
+    event ProposalCreated(uint256 indexed id, address indexed proposer, string description);
+}

--- a/ado-core/test/DAOProposal.test.ts
+++ b/ado-core/test/DAOProposal.test.ts
@@ -1,0 +1,49 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("DAO Governance Proposal Flow", function () {
+  let council: any;
+  let master: any;
+  let factory: any;
+  let proposalId: any;
+  let councilUsers: any[];
+
+  beforeEach(async () => {
+    [master, ...councilUsers] = await ethers.getSigners();
+
+    const CouncilNFT = await ethers.getContractFactory("MockCouncilNFT");
+    council = await CouncilNFT.deploy();
+
+    for (let i = 0; i < 3; i++) {
+      await council.mint(councilUsers[i].address, i);
+    }
+
+    const Factory = await ethers.getContractFactory("MockProposalFactory");
+    factory = await Factory.deploy(council.target, master.address);
+  });
+
+  it("should allow proposal creation and voting", async () => {
+    const tx = await factory.connect(councilUsers[0]).createProposal("Test proposal", "0x");
+    const receipt = await tx.wait();
+    proposalId = receipt.logs[0].args[0];
+
+    await factory.connect(councilUsers[0]).vote(proposalId, true);
+    await factory.connect(councilUsers[1]).vote(proposalId, true);
+
+    const result = await factory.getProposalStatus(proposalId);
+    expect(result).to.equal("PendingMasterApproval");
+  });
+
+  it("should allow MasterNFT to approve or veto", async () => {
+    const tx = await factory.connect(councilUsers[0]).createProposal("Do something", "0x");
+    const receipt = await tx.wait();
+    const id = receipt.logs[0].args[0];
+
+    await factory.connect(councilUsers[0]).vote(id, true);
+    await factory.connect(councilUsers[1]).vote(id, true);
+
+    await factory.connect(master).finalizeProposal(id, true);
+    const result = await factory.getProposalStatus(id);
+    expect(result).to.equal("Approved");
+  });
+});


### PR DESCRIPTION
## Summary
- add DAO proposal lifecycle test
- add mock CouncilNFT and ProposalFactory contracts

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68534509b26c8333a7b95f18721a9c88