### PR TITLE
Add subscription system with oracle tracking

### DIFF
--- a/ado-core/contracts/SubscriptionManager.sol
+++ b/ado-core/contracts/SubscriptionManager.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IOracle {
+    function reportUsage(address user, uint256 amount, bytes32 reason) external;
+    function hasDebt(address user) external view returns (bool);
+    function clearDebt(address user) external;
+}
+
+interface ISubNFT {
+    function mint(address user, uint256 duration) external;
+    function burn(address user) external;
+    function burned(address user) external view returns (bool);
+    function hasActive(address user) external view returns (bool);
+}
+
+contract SubscriptionManager {
+    address public oracle;
+    address public nft;
+    uint256 public price = 1000;
+
+    mapping(address => uint256) public lastPayment;
+
+    constructor(address _nft, address _oracle) {
+        nft = _nft;
+        oracle = _oracle;
+    }
+
+    function setMintPrice(uint256 _p) external {
+        price = _p;
+    }
+
+    function subscribe() external {
+        require(!ISubNFT(nft).burned(msg.sender), "Subscription revoked");
+
+        IOracle(oracle).reportUsage(msg.sender, price, keccak256("subscription-mint"));
+        ISubNFT(nft).mint(msg.sender, 30 days);
+        lastPayment[msg.sender] = block.timestamp;
+    }
+
+    function renew() external {
+        require(!IOracle(oracle).hasDebt(msg.sender), "Debt unpaid");
+
+        IOracle(oracle).reportUsage(msg.sender, price, keccak256("subscription-renew"));
+        ISubNFT(nft).mint(msg.sender, 30 days);
+        lastPayment[msg.sender] = block.timestamp;
+    }
+
+    function cancel() external {
+        ISubNFT(nft).burn(msg.sender);
+    }
+
+    function hasActiveSubscription(address user) external view returns (bool) {
+        return ISubNFT(nft).hasActive(user);
+    }
+}

--- a/ado-core/contracts/SubscriptionNFT.sol
+++ b/ado-core/contracts/SubscriptionNFT.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract SubscriptionNFT {
+    address public manager;
+    mapping(address => bool) public burned;
+    mapping(address => uint256) public expiry;
+
+    function setManager(address _m) external {
+        manager = _m;
+    }
+
+    function mint(address user, uint256 duration) external {
+        require(msg.sender == manager, "Only manager");
+        require(!burned[user], "Banned");
+
+        expiry[user] = block.timestamp + duration;
+    }
+
+    function burn(address user) external {
+        require(msg.sender == manager, "Only manager");
+        delete expiry[user];
+        burned[user] = true;
+    }
+
+    function hasActive(address user) external view returns (bool) {
+        return expiry[user] > block.timestamp;
+    }
+
+    function balanceOf(address user) external view returns (uint256) {
+        return expiry[user] > block.timestamp ? 1 : 0;
+    }
+}

--- a/ado-core/contracts/TRNUsageOracle.sol
+++ b/ado-core/contracts/TRNUsageOracle.sol
@@ -1,22 +1,46 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 contract TRNUsageOracle {
-    mapping(address => uint256) private balances;
+    mapping(address => int256) private balances;
+    mapping(address => int256) private debts;
 
     event EarningReported(address indexed account, uint256 amount, bytes32 postHash);
+    event UsageReported(address indexed account, uint256 amount, bytes32 reason);
 
     function reportEarning(address account, uint256 amount, bytes32 postHash) external {
-        balances[account] += amount;
+        balances[account] += int256(amount);
+        int256 debt = debts[account];
+        if (debt > 0) {
+            if (int256(amount) >= debt) {
+                debts[account] = 0;
+            } else {
+                debts[account] = debt - int256(amount);
+            }
+        }
         emit EarningReported(account, amount, postHash);
     }
 
-    function getAvailableTRN(address account) external view returns (uint256) {
+    function reportUsage(address user, uint256 amount, bytes32 reason) external {
+        balances[user] -= int256(amount);
+        debts[user] += int256(amount);
+        emit UsageReported(user, amount, reason);
+    }
+
+    function hasDebt(address user) external view returns (bool) {
+        return debts[user] > 0;
+    }
+
+    function clearDebt(address user) external {
+        debts[user] = 0;
+    }
+
+    function getAvailableTRN(address account) external view returns (int256) {
         return balances[account];
     }
 
     // Alias used in tests
-    function earnedTRN(address account) external view returns (uint256) {
+    function earnedTRN(address account) external view returns (int256) {
         return balances[account];
     }
 }

--- a/ado-core/test/Subscription.test.ts
+++ b/ado-core/test/Subscription.test.ts
@@ -1,0 +1,78 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("Subscription System", function () {
+  let oracle: any;
+  let nft: any;
+  let manager: any;
+  let user: any;
+  let deployer: any;
+
+  beforeEach(async () => {
+    [deployer, user] = await ethers.getSigners();
+
+    const Oracle = await ethers.getContractFactory("TRNUsageOracle");
+    oracle = await Oracle.deploy();
+
+    const NFT = await ethers.getContractFactory("SubscriptionNFT");
+    nft = await NFT.deploy();
+
+    const Manager = await ethers.getContractFactory("SubscriptionManager");
+    manager = await Manager.deploy(nft.target, oracle.target);
+
+    await nft.setManager(manager.target);
+    await manager.setMintPrice(1000); // 1k TRN per month
+  });
+
+  it("should mint a subscription NFT and record TRN usage", async () => {
+    await manager.connect(user).subscribe();
+
+    expect(await nft.balanceOf(user.address)).to.equal(1);
+    expect(await oracle.earnedTRN(user.address)).to.equal(-1000);
+  });
+
+  it("should auto-renew if block time advances and user has no debt", async () => {
+    await manager.connect(user).subscribe();
+
+    await oracle.clearDebt(user.address);
+
+    await ethers.provider.send("evm_increaseTime", [32 * 86400]);
+    await ethers.provider.send("evm_mine", []);
+
+    await manager.connect(user).renew();
+
+    expect(await oracle.earnedTRN(user.address)).to.equal(-2000);
+  });
+
+  it("should reject renewal if user has oracle debt", async () => {
+    await manager.connect(user).subscribe();
+
+    await ethers.provider.send("evm_increaseTime", [31 * 86400]);
+    await ethers.provider.send("evm_mine", []);
+
+    await expect(manager.connect(user).renew()).to.be.revertedWith("Debt unpaid");
+  });
+
+  it("should burn the NFT and permanently block resubscription", async () => {
+    await manager.connect(user).subscribe();
+
+    await manager.connect(user).cancel();
+
+    expect(await nft.balanceOf(user.address)).to.equal(0);
+
+    await expect(manager.connect(user).subscribe()).to.be.revertedWith("Subscription revoked");
+  });
+
+  it("should enforce hasActiveSubscription correctly", async () => {
+    await manager.connect(user).subscribe();
+
+    const result = await manager.hasActiveSubscription(user.address);
+    expect(result).to.equal(true);
+
+    await ethers.provider.send("evm_increaseTime", [40 * 86400]);
+    await ethers.provider.send("evm_mine", []);
+
+    const expired = await manager.hasActiveSubscription(user.address);
+    expect(expired).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `SubscriptionNFT` and `SubscriptionManager`
- extend `TRNUsageOracle` to track usage and debt
- add full subscription flow tests

## Testing
- `npm install`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6853542d3b00833391b24f5deac22c28