### PR TITLE
Add proposal governance frontend

### DIFF
--- a/thisrightnow/src/abi/ProposalFactory.json
+++ b/thisrightnow/src/abi/ProposalFactory.json
@@ -1,0 +1,53 @@
+[
+  {
+    "inputs": [],
+    "name": "proposalCount",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "id", "type": "uint256"}],
+    "name": "getProposal",
+    "outputs": [
+      {
+        "components": [
+          {"internalType": "string", "name": "description", "type": "string"},
+          {"internalType": "uint256", "name": "yesVotes", "type": "uint256"},
+          {"internalType": "uint256", "name": "noVotes", "type": "uint256"},
+          {"internalType": "bool", "name": "executed", "type": "bool"},
+          {"internalType": "bool", "name": "vetoed", "type": "bool"}
+        ],
+        "internalType": "struct Proposal",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "uint256", "name": "id", "type": "uint256"},
+      {"internalType": "bool", "name": "support", "type": "bool"}
+    ],
+    "name": "voteOnProposal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "id", "type": "uint256"}],
+    "name": "vetoProposal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "id", "type": "uint256"}],
+    "name": "executeProposal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/components/ProposalCard.tsx
+++ b/thisrightnow/src/components/ProposalCard.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
+import { readContract, writeContract } from "viem/wagmi";
+import factoryAbi from "@/abi/ProposalFactory.json";
+import { Proposal } from "@/hooks/useProposalData";
+
+const PROPOSAL_FACTORY_ADDRESS = "0xPROPOSAL_FACTORY";
+const COUNCIL_NFT_ADDRESS = "0xCOUNCIL_NFT";
+const MASTER_NFT_ADDRESS = "0xMASTER_NFT";
+
+const erc721Abi = [
+  {
+    inputs: [{ internalType: "address", name: "owner", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
+export function ProposalCard({ proposal }: { proposal: Proposal }) {
+  const { address } = useAccount();
+  const [isCouncil, setIsCouncil] = useState(false);
+  const [isMaster, setIsMaster] = useState(false);
+
+  useEffect(() => {
+    if (!address) return;
+    async function checkRoles() {
+      try {
+        const councilBalance: bigint = await readContract({
+          address: COUNCIL_NFT_ADDRESS,
+          abi: erc721Abi as any,
+          functionName: "balanceOf",
+          args: [address],
+        });
+        setIsCouncil(councilBalance > 0n);
+      } catch {}
+      try {
+        const masterBalance: bigint = await readContract({
+          address: MASTER_NFT_ADDRESS,
+          abi: erc721Abi as any,
+          functionName: "balanceOf",
+          args: [address],
+        });
+        setIsMaster(masterBalance > 0n);
+      } catch {}
+    }
+    checkRoles();
+  }, [address]);
+
+  async function handleVote(support: boolean) {
+    try {
+      await writeContract({
+        address: PROPOSAL_FACTORY_ADDRESS,
+        abi: factoryAbi as any,
+        functionName: "voteOnProposal",
+        args: [BigInt(proposal.id), support],
+      });
+      alert("Vote submitted");
+    } catch (err) {
+      console.warn("Vote failed", err);
+    }
+  }
+
+  async function handleVeto() {
+    try {
+      await writeContract({
+        address: PROPOSAL_FACTORY_ADDRESS,
+        abi: factoryAbi as any,
+        functionName: "vetoProposal",
+        args: [BigInt(proposal.id)],
+      });
+      alert("Proposal vetoed");
+    } catch (err) {
+      console.warn("Veto failed", err);
+    }
+  }
+
+  async function handleExecute() {
+    try {
+      await writeContract({
+        address: PROPOSAL_FACTORY_ADDRESS,
+        abi: factoryAbi as any,
+        functionName: "executeProposal",
+        args: [BigInt(proposal.id)],
+      });
+      alert("Proposal executed");
+    } catch (err) {
+      console.warn("Execute failed", err);
+    }
+  }
+
+  const status = proposal.vetoed
+    ? "Vetoed"
+    : proposal.executed
+    ? "Executed"
+    : proposal.yesVotes + proposal.noVotes === 0n
+    ? "Pending"
+    : proposal.yesVotes > proposal.noVotes
+    ? "Voting Open"
+    : "Pending";
+
+  return (
+    <div className="border p-4 rounded space-y-2">
+      <h3 className="font-semibold">Proposal #{proposal.id}</h3>
+      <p>{proposal.description}</p>
+      <div>
+        Yes: {String(proposal.yesVotes)} | No: {String(proposal.noVotes)}
+      </div>
+      <div>Status: {status}</div>
+
+      {isCouncil && !proposal.executed && !proposal.vetoed && (
+        <div className="space-x-2">
+          <button
+            className="px-2 py-1 bg-green-600 text-white rounded"
+            onClick={() => handleVote(true)}
+          >
+            Vote Yes
+          </button>
+          <button
+            className="px-2 py-1 bg-red-600 text-white rounded"
+            onClick={() => handleVote(false)}
+          >
+            Vote No
+          </button>
+        </div>
+      )}
+
+      {isMaster && !proposal.executed && !proposal.vetoed && (
+        <div className="space-x-2 mt-2">
+          <button
+            className="px-2 py-1 bg-yellow-600 text-white rounded"
+            onClick={handleVeto}
+          >
+            Veto
+          </button>
+          <button
+            className="px-2 py-1 bg-blue-600 text-white rounded"
+            onClick={handleExecute}
+          >
+            Execute
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/thisrightnow/src/hooks/useProposalData.ts
+++ b/thisrightnow/src/hooks/useProposalData.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { readContract } from "viem/wagmi";
+import factoryAbi from "@/abi/ProposalFactory.json";
+
+const PROPOSAL_FACTORY_ADDRESS = "0xPROPOSAL_FACTORY";
+
+export interface Proposal {
+  id: number;
+  description: string;
+  yesVotes: bigint;
+  noVotes: bigint;
+  executed: boolean;
+  vetoed: boolean;
+}
+
+export function useProposalData() {
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const count = await readContract({
+          address: PROPOSAL_FACTORY_ADDRESS,
+          abi: factoryAbi as any,
+          functionName: "proposalCount",
+        });
+
+        const items: Proposal[] = [];
+        for (let i = 0; i < Number(count); i++) {
+          try {
+            const data: any = await readContract({
+              address: PROPOSAL_FACTORY_ADDRESS,
+              abi: factoryAbi as any,
+              functionName: "getProposal",
+              args: [BigInt(i)],
+            });
+            items.push({ id: i, ...(data as any) });
+          } catch (err) {
+            console.warn("Failed to fetch proposal", i, err);
+          }
+        }
+        setProposals(items);
+      } catch (err) {
+        console.warn("Failed loading proposals", err);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    load();
+  }, []);
+
+  return { proposals, isLoading };
+}

--- a/thisrightnow/src/pages/proposal.tsx
+++ b/thisrightnow/src/pages/proposal.tsx
@@ -1,0 +1,21 @@
+import { withSubscriptionGate } from "@/components/withSubscriptionGate";
+import { ProposalCard } from "@/components/ProposalCard";
+import { useProposalData } from "@/hooks/useProposalData";
+
+function ProposalPage() {
+  const { proposals, isLoading } = useProposalData();
+
+  if (isLoading) return <div className="p-6">Loading proposals...</div>;
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Active Proposals</h1>
+      {proposals.length === 0 && <div>No proposals found.</div>}
+      {proposals.map((p) => (
+        <ProposalCard key={p.id} proposal={p} />
+      ))}
+    </div>
+  );
+}
+
+export default withSubscriptionGate(ProposalPage);


### PR DESCRIPTION
## Summary
- show active proposals behind subscription gate
- fetch proposals from factory contract
- include ProposalFactory ABI
- allow voting, veto, and execute actions

## Testing
- `npm test` in `ado-core`

------
https://chatgpt.com/codex/tasks/task_e_68535db98e408333bf4f2bdfecfbcc32