### PR TITLE
Add moderation pipeline contracts and tests

### DIFF
--- a/ado-core/contracts/BurnRegistry.sol
+++ b/ado-core/contracts/BurnRegistry.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IModerationLog {
+    function log(bytes32 postHash, string calldata action, string calldata reason) external;
+}
+
+contract BurnRegistry {
+    address public moderationLog;
+
+    constructor(address _log) {
+        moderationLog = _log;
+    }
+
+    function burnPost(bytes32 postHash, string calldata reason) external {
+        IModerationLog(moderationLog).log(postHash, "Burned", reason);
+    }
+}

--- a/ado-core/contracts/CountryRulesetManager.sol
+++ b/ado-core/contracts/CountryRulesetManager.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract CountryRulesetManager {
+    mapping(string => mapping(string => bool)) public policies;
+
+    function setCountryPolicy(string calldata country, string[] calldata categories) external {
+        for (uint256 i = 0; i < categories.length; i++) {
+            policies[country][categories[i]] = true;
+        }
+    }
+
+    function isBlocked(string calldata country, string calldata category) external view returns (bool) {
+        return policies[country][category];
+    }
+}

--- a/ado-core/contracts/FlagEscalator.sol
+++ b/ado-core/contracts/FlagEscalator.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IModerationLog {
+    function log(bytes32 postHash, string calldata action, string calldata reason) external;
+}
+
+contract FlagEscalator {
+    address public moderationLog;
+
+    mapping(bytes32 => uint256) public burnCount;
+    mapping(bytes32 => bool) public escalated;
+
+    constructor(address _log) {
+        moderationLog = _log;
+    }
+
+    function burnFlag(bytes32 postHash) external {
+        burnCount[postHash] += 1;
+    }
+
+    function aiEscalate(bytes32 postHash) external {
+        require(burnCount[postHash] >= 2, "Not enough burns");
+        escalated[postHash] = true;
+        IModerationLog(moderationLog).log(postHash, "Escalated", "");
+    }
+
+    function isEscalated(bytes32 postHash) external view returns (bool) {
+        return escalated[postHash];
+    }
+}

--- a/ado-core/contracts/GeoOracle.sol
+++ b/ado-core/contracts/GeoOracle.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface ICountryRulesetManager {
+    function isBlocked(string calldata country, string calldata category) external view returns (bool);
+}
+
+interface IModerationLog {
+    function log(bytes32 postHash, string calldata action, string calldata reason) external;
+}
+
+contract GeoOracle {
+    address public countryRules;
+    address public moderationLog;
+
+    mapping(bytes32 => mapping(string => bool)) public blocked;
+
+    constructor(address _countryRules, address _log) {
+        countryRules = _countryRules;
+        moderationLog = _log;
+    }
+
+    function enforceGeoBlock(bytes32 postHash, string calldata country, string calldata category) external {
+        blocked[postHash][country] = true;
+        IModerationLog(moderationLog).log(postHash, "Blocked", category);
+    }
+
+    function isVisible(bytes32 postHash, string calldata country) external view returns (bool) {
+        return !blocked[postHash][country];
+    }
+
+    function overrideUnblock(bytes32 postHash, string calldata country) external {
+        blocked[postHash][country] = false;
+        IModerationLog(moderationLog).log(postHash, "Unblocked", country);
+    }
+}

--- a/ado-core/contracts/ModerationLog.sol
+++ b/ado-core/contracts/ModerationLog.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract ModerationLog {
+    struct Entry {
+        string action;
+        string reason;
+    }
+
+    mapping(bytes32 => Entry) public logs;
+
+    function log(bytes32 postHash, string calldata action, string calldata reason) external {
+        logs[postHash] = Entry(action, reason);
+    }
+
+    function getPostModerationLog(bytes32 postHash) external view returns (Entry memory) {
+        return logs[postHash];
+    }
+}

--- a/ado-core/test/Moderation.test.ts
+++ b/ado-core/test/Moderation.test.ts
@@ -1,0 +1,68 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { Contract } from "ethers";
+
+describe("Moderation Pipeline", function () {
+  let owner: any, user1: any, user2: any, dao: any, aiAgent: any, council: any;
+  let moderationLog: Contract;
+  let flagEscalator: Contract;
+  let burnRegistry: Contract;
+  let geoOracle: Contract;
+  let countryRules: Contract;
+
+  const postHash = ethers.keccak256(ethers.toUtf8Bytes("sample-post-1"));
+
+  beforeEach(async function () {
+    [owner, user1, user2, dao, aiAgent, council] = await ethers.getSigners();
+
+    const ModerationLog = await ethers.getContractFactory("ModerationLog");
+    moderationLog = await ModerationLog.deploy();
+
+    const FlagEscalator = await ethers.getContractFactory("FlagEscalator");
+    flagEscalator = await FlagEscalator.deploy(moderationLog.target);
+
+    const BurnRegistry = await ethers.getContractFactory("BurnRegistry");
+    burnRegistry = await BurnRegistry.deploy(moderationLog.target);
+
+    const CountryRulesetManager = await ethers.getContractFactory("CountryRulesetManager");
+    countryRules = await CountryRulesetManager.deploy();
+
+    const GeoOracle = await ethers.getContractFactory("GeoOracle");
+    geoOracle = await GeoOracle.deploy(countryRules.target, moderationLog.target);
+  });
+
+  it("should flag and escalate a post via user burns", async function () {
+    await flagEscalator.connect(user1).burnFlag(postHash);
+    await flagEscalator.connect(user2).burnFlag(postHash);
+
+    await flagEscalator.connect(aiAgent).aiEscalate(postHash);
+
+    const flagged = await flagEscalator.isEscalated(postHash);
+    expect(flagged).to.be.true;
+  });
+
+  it("should allow DAO to burn the post and log it", async function () {
+    await burnRegistry.connect(dao).burnPost(postHash, "Hate speech");
+
+    const log = await moderationLog.getPostModerationLog(postHash);
+    expect(log.action).to.equal("Burned");
+    expect(log.reason).to.equal("Hate speech");
+  });
+
+  it("should block post visibility via GeoOracle", async function () {
+    await countryRules.setCountryPolicy("CN", ["HateSpeech"]);
+
+    await geoOracle.connect(owner).enforceGeoBlock(postHash, "CN", "HateSpeech");
+
+    const visible = await geoOracle.isVisible(postHash, "CN");
+    expect(visible).to.be.false;
+  });
+
+  it("should allow override by DAO to unban post", async function () {
+    await geoOracle.connect(owner).enforceGeoBlock(postHash, "CN", "NSFW");
+    await geoOracle.connect(dao).overrideUnblock(postHash, "CN");
+
+    const visible = await geoOracle.isVisible(postHash, "CN");
+    expect(visible).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- add simple ModerationLog, FlagEscalator, BurnRegistry, GeoOracle and CountryRulesetManager contracts
- create Moderation.test.ts exercising flagging, burning and geo-blocking

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545440a2e483339206befcddd83e10