### PR TITLE
Upgrade ModerationLog audit trail

### DIFF
--- a/ado-core/contracts/BurnRegistry.sol
+++ b/ado-core/contracts/BurnRegistry.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.24;
 
 interface IModerationLog {
-    function log(bytes32 postHash, string calldata action, string calldata reason) external;
+    enum ActionType { None, Burned, Flagged, Blocked, Unblocked, Escalated }
+    function logAction(bytes32 postHash, ActionType action, string calldata reason) external;
 }
 
 contract BurnRegistry {
@@ -13,6 +14,6 @@ contract BurnRegistry {
     }
 
     function burnPost(bytes32 postHash, string calldata reason) external {
-        IModerationLog(moderationLog).log(postHash, "Burned", reason);
+        IModerationLog(moderationLog).logAction(postHash, IModerationLog.ActionType.Burned, reason);
     }
 }

--- a/ado-core/contracts/FlagEscalator.sol
+++ b/ado-core/contracts/FlagEscalator.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.24;
 
 interface IModerationLog {
-    function log(bytes32 postHash, string calldata action, string calldata reason) external;
+    enum ActionType { None, Burned, Flagged, Blocked, Unblocked, Escalated }
+    function logAction(bytes32 postHash, ActionType action, string calldata reason) external;
 }
 
 contract FlagEscalator {
@@ -22,7 +23,7 @@ contract FlagEscalator {
     function aiEscalate(bytes32 postHash) external {
         require(burnCount[postHash] >= 2, "Not enough burns");
         escalated[postHash] = true;
-        IModerationLog(moderationLog).log(postHash, "Escalated", "");
+        IModerationLog(moderationLog).logAction(postHash, IModerationLog.ActionType.Escalated, "");
     }
 
     function isEscalated(bytes32 postHash) external view returns (bool) {

--- a/ado-core/contracts/GeoOracle.sol
+++ b/ado-core/contracts/GeoOracle.sol
@@ -6,7 +6,8 @@ interface ICountryRulesetManager {
 }
 
 interface IModerationLog {
-    function log(bytes32 postHash, string calldata action, string calldata reason) external;
+    enum ActionType { None, Burned, Flagged, Blocked, Unblocked, Escalated }
+    function logAction(bytes32 postHash, ActionType action, string calldata reason) external;
 }
 
 contract GeoOracle {
@@ -22,7 +23,7 @@ contract GeoOracle {
 
     function enforceGeoBlock(bytes32 postHash, string calldata country, string calldata category) external {
         blocked[postHash][country] = true;
-        IModerationLog(moderationLog).log(postHash, "Blocked", category);
+        IModerationLog(moderationLog).logAction(postHash, IModerationLog.ActionType.Blocked, category);
     }
 
     function isVisible(bytes32 postHash, string calldata country) external view returns (bool) {
@@ -31,6 +32,6 @@ contract GeoOracle {
 
     function overrideUnblock(bytes32 postHash, string calldata country) external {
         blocked[postHash][country] = false;
-        IModerationLog(moderationLog).log(postHash, "Unblocked", country);
+        IModerationLog(moderationLog).logAction(postHash, IModerationLog.ActionType.Unblocked, country);
     }
 }

--- a/ado-core/test/Moderation.test.ts
+++ b/ado-core/test/Moderation.test.ts
@@ -44,8 +44,8 @@ describe("Moderation Pipeline", function () {
   it("should allow DAO to burn the post and log it", async function () {
     await burnRegistry.connect(dao).burnPost(postHash, "Hate speech");
 
-    const log = await moderationLog.getPostModerationLog(postHash);
-    expect(log.action).to.equal("Burned");
+    const log = await moderationLog.getLatestAction(postHash);
+    expect(log.action).to.equal(1); // ActionType.Burned
     expect(log.reason).to.equal("Hate speech");
   });
 


### PR DESCRIPTION
## Summary
- implement ModerationLog with ActionType enum and audit trail
- update registry contracts to use `logAction`
- adjust moderation tests for new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854588702d883338dce22b3d262b5ac