### PR TITLE
Enhance BurnRegistry with access control

### DIFF
--- a/ado-core/contracts/BurnRegistry.sol
+++ b/ado-core/contracts/BurnRegistry.sol
@@ -7,13 +7,47 @@ interface IModerationLog {
 }
 
 contract BurnRegistry {
-    address public moderationLog;
+    IModerationLog public moderationLog;
+    address public daoAddress;
+    address public councilMod;
+    mapping(bytes32 => bool) public isBurned;
 
-    constructor(address _log) {
-        moderationLog = _log;
+    event PostBurned(bytes32 indexed postHash, string reason, address actor);
+
+    modifier onlyDAO() {
+        require(msg.sender == daoAddress, "Not DAO");
+        _;
+    }
+
+    modifier onlyCouncilMod() {
+        require(msg.sender == councilMod, "Not council mod");
+        _;
+    }
+
+    constructor(address _moderationLog) {
+        moderationLog = IModerationLog(_moderationLog);
+        daoAddress = msg.sender;
+    }
+
+    function setDAO(address _dao) external onlyDAO {
+        daoAddress = _dao;
+    }
+
+    function setCouncilMod(address _mod) external onlyDAO {
+        councilMod = _mod;
     }
 
     function burnPost(bytes32 postHash, string calldata reason) external {
-        IModerationLog(moderationLog).logAction(postHash, IModerationLog.ActionType.Burned, reason);
+        require(!isBurned[postHash], "Already burned");
+        require(msg.sender == daoAddress || msg.sender == councilMod, "Not authorized");
+
+        isBurned[postHash] = true;
+
+        moderationLog.logAction(postHash, IModerationLog.ActionType.Burned, reason);
+        emit PostBurned(postHash, reason, msg.sender);
+    }
+
+    function isContentBurned(bytes32 postHash) external view returns (bool) {
+        return isBurned[postHash];
     }
 }

--- a/ado-core/test/Moderation.test.ts
+++ b/ado-core/test/Moderation.test.ts
@@ -24,6 +24,7 @@ describe("Moderation Pipeline", function () {
 
     const BurnRegistry = await ethers.getContractFactory("BurnRegistry");
     burnRegistry = await BurnRegistry.deploy(moderationLog.target);
+    await burnRegistry.setDAO(dao.address);
 
     const CountryRulesetManager = await ethers.getContractFactory("CountryRulesetManager");
     countryRules = await CountryRulesetManager.deploy();


### PR DESCRIPTION
## Summary
- expand `BurnRegistry` to store DAO and council moderator addresses
- add checks to prevent multiple burns and require authorized callers
- emit `PostBurned` event and track burns
- update moderation tests to configure DAO address

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545c4fa2d883338c79718d5b1953f7