### PR TITLE
Add TrustScoreEngine script

### DIFF
--- a/indexer/TrustScoreEngine.ts
+++ b/indexer/TrustScoreEngine.ts
@@ -1,0 +1,105 @@
+import fs from "fs";
+import path from "path";
+
+export type ContributorStats = {
+  blessings: number;
+  burns: number;
+  retrns: number;
+  posts: number;
+  geoBlocks: number;
+  aiFlags: number;
+  deletedPosts: number;
+  createdAt: number; // timestamp
+};
+
+export type TrustScore = {
+  address: string;
+  score: number;
+  details: {
+    blessRate: number;
+    burnRate: number;
+    retrnRate: number;
+    geoPenalty: number;
+    aiPenalty: number;
+    ageBonus: number;
+  };
+};
+
+// Dummy mock data – replace with real event/indexer data
+const mockContributorData: Record<string, ContributorStats> = {
+  "0xUserA": {
+    blessings: 80,
+    burns: 20,
+    retrns: 25,
+    posts: 50,
+    geoBlocks: 1,
+    aiFlags: 2,
+    deletedPosts: 0,
+    createdAt: Date.now() - 1000 * 60 * 60 * 24 * 365 * 2, // 2 years ago
+  },
+  "0xUserB": {
+    blessings: 20,
+    burns: 60,
+    retrns: 2,
+    posts: 30,
+    geoBlocks: 5,
+    aiFlags: 10,
+    deletedPosts: 4,
+    createdAt: Date.now() - 1000 * 60 * 60 * 24 * 60, // 2 months ago
+  },
+};
+
+export function computeTrustScore(addr: string, stats: ContributorStats): TrustScore {
+  const blessRate = stats.blessings / Math.max(stats.posts, 1);
+  const burnRate = stats.burns / Math.max(stats.posts, 1);
+  const retrnRate = stats.retrns / Math.max(stats.posts, 1);
+
+  const geoPenalty = stats.geoBlocks * 0.05;
+  const aiPenalty = stats.aiFlags * 0.1;
+  const deletionPenalty = stats.deletedPosts * 0.05;
+
+  const accountAgeYears = (Date.now() - stats.createdAt) / (1000 * 60 * 60 * 24 * 365);
+  const ageBonus = Math.min(accountAgeYears * 0.1, 0.5);
+
+  // Weighted composite trust score (out of 1.0)
+  let score =
+    0.4 * blessRate +
+    0.2 * retrnRate -
+    0.2 * burnRate -
+    geoPenalty -
+    aiPenalty -
+    deletionPenalty +
+    ageBonus;
+
+  score = Math.max(0, Math.min(1, score)); // clamp between 0 and 1
+
+  return {
+    address: addr,
+    score,
+    details: {
+      blessRate,
+      burnRate,
+      retrnRate,
+      geoPenalty,
+      aiPenalty,
+      ageBonus,
+    },
+  };
+}
+
+function buildTrustIndex() {
+  const index: Record<string, TrustScore> = {};
+
+  for (const [addr, stats] of Object.entries(mockContributorData)) {
+    index[addr] = computeTrustScore(addr, stats);
+  }
+
+  const outputPath = path.join(__dirname, "output", "trustIndex.json");
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, JSON.stringify(index, null, 2));
+  console.log(`✅ Trust index written to ${outputPath}`);
+}
+
+if (require.main === module) {
+  buildTrustIndex();
+}

--- a/indexer/output/trustIndex.json
+++ b/indexer/output/trustIndex.json
@@ -1,0 +1,26 @@
+{
+  "0xUserA": {
+    "address": "0xUserA",
+    "score": 0.6100000000000001,
+    "details": {
+      "blessRate": 1.6,
+      "burnRate": 0.4,
+      "retrnRate": 0.5,
+      "geoPenalty": 0.05,
+      "aiPenalty": 0.2,
+      "ageBonus": 0.2
+    }
+  },
+  "0xUserB": {
+    "address": "0xUserB",
+    "score": 0,
+    "details": {
+      "blessRate": 0.6666666666666666,
+      "burnRate": 2,
+      "retrnRate": 0.06666666666666667,
+      "geoPenalty": 0.25,
+      "aiPenalty": 1,
+      "ageBonus": 0.01643835616438356
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add TrustScoreEngine to compute contributor reputation
- output initial trust index with mock data

## Testing
- `npx ts-node -O '{"module":"commonjs"}' indexer/TrustScoreEngine.ts`
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854703010488333b279e7395c456836