### PR TITLE
Add tag accuracy tracker

### DIFF
--- a/indexer/TagAccuracyTracker.ts
+++ b/indexer/TagAccuracyTracker.ts
@@ -1,0 +1,47 @@
+import fs from "fs";
+import path from "path";
+
+// Mock metadata from the post system
+const postMeta = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "output", "postMetadata.json"), "utf-8")
+) as Record<string, { author: string; tags: string[] }>;
+
+// AI-labeled truth set
+const aiTags = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "output", "postTags.json"), "utf-8")
+) as Record<string, string[]>;
+
+type TagAccuracyMap = Record<string, { correct: number; total: number; accuracy: number }>;
+
+function calcTagAccuracy() {
+  const accMap: TagAccuracyMap = {};
+
+  for (const [postHash, { author, tags }] of Object.entries(postMeta)) {
+    const ai = new Set(aiTags[postHash] || []);
+    const user = new Set(tags || []);
+
+    const truePositives = [...user].filter((tag) => ai.has(tag) && tag !== "None").length;
+    const totalRelevant = ai.size - (ai.has("None") ? 1 : 0);
+
+    if (!accMap[author]) accMap[author] = { correct: 0, total: 0, accuracy: 0 };
+
+    accMap[author].correct += truePositives;
+    accMap[author].total += totalRelevant;
+  }
+
+  for (const addr in accMap) {
+    const { correct, total } = accMap[addr];
+    accMap[addr].accuracy = total === 0 ? 1 : correct / total;
+  }
+
+  fs.writeFileSync(
+    path.join(__dirname, "output", "tagAccuracy.json"),
+    JSON.stringify(accMap, null, 2)
+  );
+
+  console.log("✅ Tag accuracy scored and saved.");
+}
+
+if (require.main === module) {
+  calcTagAccuracy();
+}

--- a/indexer/output/postMetadata.json
+++ b/indexer/output/postMetadata.json
@@ -1,0 +1,14 @@
+{
+  "0xabc123": {
+    "author": "0xAuthorA",
+    "tags": ["HateSpeech"]
+  },
+  "0xdef456": {
+    "author": "0xAuthorB",
+    "tags": ["Crypto"]
+  },
+  "0xghi789": {
+    "author": "0xAuthorA",
+    "tags": ["None"]
+  }
+}

--- a/indexer/output/postTags.json
+++ b/indexer/output/postTags.json
@@ -1,0 +1,5 @@
+{
+  "0xabc123": ["HateSpeech"],
+  "0xdef456": ["Crypto", "Spam"],
+  "0xghi789": ["MedicalMisinformation", "NSFW"]
+}

--- a/indexer/output/tagAccuracy.json
+++ b/indexer/output/tagAccuracy.json
@@ -1,0 +1,12 @@
+{
+  "0xAuthorA": {
+    "correct": 1,
+    "total": 3,
+    "accuracy": 0.3333333333333333
+  },
+  "0xAuthorB": {
+    "correct": 1,
+    "total": 2,
+    "accuracy": 0.5
+  }
+}


### PR DESCRIPTION
## Summary
- introduce TagAccuracyTracker script that compares user labels to AI tags
- include example post metadata and tag accuracy output
- copy AI tag results to indexer output for easier consumption

## Testing
- `TS_NODE_COMPILER_OPTIONS='{ "module": "CommonJS" }' ./ado-core/node_modules/.bin/ts-node indexer/TagAccuracyTracker.ts`
- `npm --prefix ado-core test`

------
https://chatgpt.com/codex/tasks/task_e_68547916fc088333957cd7426d88128b