### PR TITLE
Add on-chain appeals log

### DIFF
--- a/ado-core/contracts/ModerationLog.sol
+++ b/ado-core/contracts/ModerationLog.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.24;
 contract ModerationLog {
     enum ActionType { None, Burned, Flagged, Blocked, Unblocked, Escalated }
 
+    // Appeal logging enums
+    enum AppealReason { GeoBlock, PostBurned, MisTag, AIFlag }
+    enum AppealResolution { None, Approved, Denied, Escalated }
+
     struct ModerationEntry {
         ActionType action;
         string reason;
@@ -11,9 +15,22 @@ contract ModerationLog {
         uint256 timestamp;
     }
 
+    struct Appeal {
+        address submitter;
+        bytes32 postHash;
+        AppealReason reason;
+        uint256 timestamp;
+        address moderator;
+        AppealResolution resolution;
+    }
+
     mapping(bytes32 => ModerationEntry[]) public postLogs;
 
+    Appeal[] public appeals;
+
     event ModerationEvent(bytes32 indexed postHash, ActionType action, string reason, address actor);
+    event AppealSubmitted(uint256 indexed id, address indexed submitter, bytes32 indexed postHash, AppealReason reason);
+    event AppealResolved(uint256 indexed id, address indexed moderator, AppealResolution resolution);
 
     modifier validAction(ActionType action) {
         require(action != ActionType.None, "Invalid action");
@@ -41,5 +58,42 @@ contract ModerationLog {
 
     function getAllActions(bytes32 postHash) external view returns (ModerationEntry[] memory) {
         return postLogs[postHash];
+    }
+
+    // ----- Appeal Handling -----
+
+    function submitAppeal(bytes32 postHash, AppealReason reason) external returns (uint256) {
+        appeals.push(Appeal({
+            submitter: msg.sender,
+            postHash: postHash,
+            reason: reason,
+            timestamp: block.timestamp,
+            moderator: address(0),
+            resolution: AppealResolution.None
+        }));
+
+        uint256 id = appeals.length - 1;
+        emit AppealSubmitted(id, msg.sender, postHash, reason);
+        return id;
+    }
+
+    function resolveAppeal(uint256 id, AppealResolution resolution) external {
+        require(id < appeals.length, "Invalid appeal ID");
+        Appeal storage a = appeals[id];
+        require(a.resolution == AppealResolution.None, "Already resolved");
+
+        a.moderator = msg.sender;
+        a.resolution = resolution;
+
+        emit AppealResolved(id, msg.sender, resolution);
+    }
+
+    function getAppeal(uint256 id) external view returns (Appeal memory) {
+        require(id < appeals.length, "Invalid appeal ID");
+        return appeals[id];
+    }
+
+    function appealCount() external view returns (uint256) {
+        return appeals.length;
     }
 }

--- a/ado-core/test/Appeals.test.ts
+++ b/ado-core/test/Appeals.test.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { Contract } from "ethers";
+
+describe("Moderation Appeals", function () {
+  let log: Contract;
+  let user: any;
+  let moderator: any;
+
+  beforeEach(async () => {
+    [user, moderator] = await ethers.getSigners();
+    const ModerationLog = await ethers.getContractFactory("ModerationLog");
+    log = await ModerationLog.deploy();
+  });
+
+  it("should submit and resolve an appeal", async () => {
+    const postHash = ethers.keccak256(ethers.toUtf8Bytes("appeal-post"));
+
+    await log.connect(user).submitAppeal(postHash, 0);
+
+    expect(await log.appealCount()).to.equal(1);
+
+    const initial = await log.getAppeal(0);
+    expect(initial.submitter).to.equal(user.address);
+    expect(initial.postHash).to.equal(postHash);
+    expect(initial.resolution).to.equal(0); // AppealResolution.None
+
+    await log.connect(moderator).resolveAppeal(0, 1); // Approved
+
+    const resolved = await log.getAppeal(0);
+    expect(resolved.moderator).to.equal(moderator.address);
+    expect(resolved.resolution).to.equal(1); // Approved
+  });
+});

--- a/thisrightnow/src/pages/appeal.tsx
+++ b/thisrightnow/src/pages/appeal.tsx
@@ -1,8 +1,13 @@
 import { useState } from "react";
 import { useAccount } from "wagmi";
+import { loadContract } from "@/utils/contract";
+import { ethers } from "ethers";
+import ModerationLogABI from "@/abi/ModerationLog.json";
 
 export default function AppealForm() {
   const { address, isConnected } = useAccount();
+
+  const MODERATION_LOG = import.meta.env.VITE_MODERATION_LOG;
 
   const [postHash, setPostHash] = useState("");
   const [reason, setReason] = useState("GeoBlock");
@@ -10,7 +15,19 @@ export default function AppealForm() {
   const [submitted, setSubmitted] = useState(false);
 
   const handleSubmit = async () => {
-    // Replace with actual backend or indexer logic
+    const provider = new ethers.BrowserProvider((window as any).ethereum);
+    const signer = await provider.getSigner();
+    const moderationLogContract = await loadContract(
+      MODERATION_LOG,
+      ModerationLogABI as any,
+      signer
+    );
+
+    await moderationLogContract.submitAppeal(
+      ethers.keccak256(ethers.toUtf8Bytes(postHash)),
+      0
+    );
+
     const appeal = {
       address,
       postHash,


### PR DESCRIPTION
## Summary
- extend ModerationLog.sol with on-chain appeal tracking
- expose submitAppeal and resolveAppeal in ModerationLog
- write tests for the appeal flow
- wire up submitAppeal in the appeal form
- wire up resolveAppeal in the appeals queue

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6854838851cc8333a3779bfd8c1dc82d