### PR TITLE
Implement boost refund tracking in oracle

### DIFF
--- a/ado-core/contracts/BoostingModule.sol
+++ b/ado-core/contracts/BoostingModule.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+interface ITRNOracle {
+    function recordBoostRefund(address user, uint256 amount) external;
+}
+
 contract BoostingModule {
     struct Boost {
         address booster;
@@ -9,18 +13,40 @@ contract BoostingModule {
     }
 
     mapping(bytes32 => Boost) private boosts;
+    address public oracle;
 
-    function startBoost(bytes32 postHash, uint256 amount) external {
+    constructor(address _oracle) {
+        oracle = _oracle;
+    }
+
+    function _startBoost(bytes32 postHash, uint256 amount, address booster) internal {
         Boost storage b = boosts[postHash];
-        b.booster = msg.sender;
+        b.booster = booster;
         b.amount = amount;
         b.active = true;
+    }
+
+    function startBoost(bytes32 postHash, uint256 amount) external {
+        _startBoost(postHash, amount, msg.sender);
+    }
+
+    function startBoost(uint256 postId, uint256 amount) external {
+        bytes32 postHash = bytes32(postId);
+        _startBoost(postHash, amount, msg.sender);
     }
 
     function endBoost(bytes32 postHash) external {
         Boost storage b = boosts[postHash];
         require(b.active, "not active");
         b.active = false;
+    }
+
+    function simulatePostBurn(uint256 postId) external {
+        bytes32 postHash = bytes32(postId);
+        Boost storage b = boosts[postHash];
+        require(b.active, "not active");
+        b.active = false;
+        ITRNOracle(oracle).recordBoostRefund(b.booster, b.amount);
     }
 
     function getBoost(bytes32 postHash) external view returns (Boost memory) {

--- a/ado-core/contracts/TRNUsageOracle.sol
+++ b/ado-core/contracts/TRNUsageOracle.sol
@@ -4,9 +4,11 @@ pragma solidity ^0.8.24;
 contract TRNUsageOracle {
     mapping(address => int256) private balances;
     mapping(address => int256) private debts;
+    mapping(address => uint256) public boostRefunds;
 
     event EarningReported(address indexed account, uint256 amount, bytes32 postHash);
     event UsageReported(address indexed account, uint256 amount, bytes32 reason);
+    event BoostRefunded(address indexed user, uint256 amount);
 
     function reportEarning(address account, uint256 amount, bytes32 postHash) external {
         balances[account] += int256(amount);
@@ -25,6 +27,12 @@ contract TRNUsageOracle {
         balances[user] -= int256(amount);
         debts[user] += int256(amount);
         emit UsageReported(user, amount, reason);
+    }
+
+    function recordBoostRefund(address user, uint256 amount) external {
+        boostRefunds[user] += amount;
+        balances[user] += int256(amount);
+        emit BoostRefunded(user, amount);
     }
 
     function hasDebt(address user) external view returns (bool) {

--- a/ado-core/test/BoostRefund.test.ts
+++ b/ado-core/test/BoostRefund.test.ts
@@ -1,0 +1,31 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { parseEther } from "ethers";
+
+describe("Boosting Refund Flow", function () {
+  let oracle: any, boost: any;
+  let user: any;
+
+  beforeEach(async () => {
+    [user] = await ethers.getSigners();
+
+    const Oracle = await ethers.getContractFactory("TRNUsageOracle");
+    oracle = await Oracle.deploy();
+
+    const Boosting = await ethers.getContractFactory("BoostingModule");
+    boost = await Boosting.deploy(oracle.target);
+  });
+
+  it("should refund TRN when boost ends early and record it in oracle", async () => {
+    const boostAmount = parseEther("10");
+
+    await boost
+      .connect(user)
+      ["startBoost(uint256,uint256)"](1, boostAmount);
+
+    await boost.connect(user).simulatePostBurn(1);
+
+    const earned = await oracle.earnedTRN(user.address);
+    expect(earned).to.equal(boostAmount);
+  });
+});

--- a/ado-core/test/BoostingModule.test.ts
+++ b/ado-core/test/BoostingModule.test.ts
@@ -13,14 +13,16 @@ describe("BoostingModule", function () {
     oracle = await Oracle.deploy();
 
     const Boosting = await ethers.getContractFactory("BoostingModule");
-    boost = await Boosting.deploy();
+    boost = await Boosting.deploy(oracle.target);
   });
 
   it("should start a boost campaign", async () => {
     const postHash = ethers.keccak256(ethers.toUtf8Bytes("boostPost"));
 
     const amount = 30; // Simulated 3x cost
-    await boost.connect(booster).startBoost(postHash, amount);
+    await boost
+      .connect(booster)
+      ["startBoost(bytes32,uint256)"](postHash, amount);
 
     const boostData = await boost.getBoost(postHash);
     expect(boostData.booster).to.equal(booster.address);
@@ -32,7 +34,9 @@ describe("BoostingModule", function () {
     const postHash = ethers.keccak256(ethers.toUtf8Bytes("boostPost"));
     const amount = 90;
 
-    await boost.connect(booster).startBoost(postHash, amount);
+    await boost
+      .connect(booster)
+      ["startBoost(bytes32,uint256)"](postHash, amount);
     await boost.endBoost(postHash);
 
     const boostData = await boost.getBoost(postHash);
@@ -45,7 +49,9 @@ describe("BoostingModule", function () {
     const postHash = ethers.keccak256(ethers.toUtf8Bytes("burnedBoost"));
     const spent = 60;
 
-    await boost.connect(booster).startBoost(postHash, spent);
+    await boost
+      .connect(booster)
+      ["startBoost(bytes32,uint256)"](postHash, spent);
     await boost.endBoost(postHash);
 
     // Simulate refund: oracle removes debt


### PR DESCRIPTION
## Summary
- update `BoostingModule` to notify oracle on burn refund
- extend `TRNUsageOracle` with boost refund bookkeeping
- fix existing tests for new constructor and overloads
- add unit test for boost refund flow

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6854e0b630148333a3d82a1b6bd192f7