### PR TITLE
Implement trust-weighted retrn lotto

### DIFF
--- a/ado-core/contracts/LottoModule.sol
+++ b/ado-core/contracts/LottoModule.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IRetrnIndex {
+    function postWeight(uint256 postId) external view returns (uint256);
+    function getPostCount() external view returns (uint256);
+    function getPostAt(uint256 index) external view returns (uint256);
+}
+
+interface ITRNOracle {
+    function reportEarning(address user, uint256 amount, bytes32 source) external;
+}
+
+contract LottoModule {
+    uint256 public constant REWARD = 1e18;
+
+    IRetrnIndex public retrnIndex;
+    ITRNOracle public oracle;
+    address public owner;
+
+    uint256[] private posts;
+    mapping(uint256 => address) public poster;
+    mapping(uint256 => bool) public paid;
+
+    event RetrnLottoWinner(address indexed poster, uint256 postId, uint256 reward);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    constructor(address _index, address _oracle) {
+        retrnIndex = IRetrnIndex(_index);
+        oracle = ITRNOracle(_oracle);
+        owner = msg.sender;
+    }
+
+    function setPoster(uint256 postId, address postAuthor) external onlyOwner {
+        if (poster[postId] == address(0)) {
+            posts.push(postId);
+        }
+        poster[postId] = postAuthor;
+    }
+
+    function triggerPayout() external {
+        uint256 count = posts.length;
+        if (count == 0) return;
+
+        uint256 winningPost;
+        uint256 highest;
+
+        for (uint256 i = 0; i < count; i++) {
+            uint256 id = posts[i];
+            if (paid[id]) continue;
+            uint256 weight = retrnIndex.postWeight(id);
+            if (weight > highest) {
+                highest = weight;
+                winningPost = id;
+            }
+        }
+
+        if (winningPost == 0) return;
+
+        paid[winningPost] = true;
+        address winPoster = poster[winningPost];
+        oracle.reportEarning(winPoster, REWARD, keccak256("retrn-lotto"));
+        emit RetrnLottoWinner(winPoster, winningPost, REWARD);
+    }
+}
+

--- a/ado-core/contracts/RetrnIndex.sol
+++ b/ado-core/contracts/RetrnIndex.sol
@@ -6,13 +6,53 @@ contract RetrnIndex {
     // Weight is multiplier * 100 to preserve decimals (e.g. 150 = 1.5x)
     event WeightedRetrn(address indexed retrnr, bytes32 indexed postHash, uint256 weight);
 
+    address public owner;
+
     mapping(address => uint256) public trustScore;
+    mapping(uint256 => uint256) public postWeight;
+    uint256[] private posts;
+    mapping(uint256 => bool) private seen;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function setTrustScore(address user, uint256 score) external onlyOwner {
+        trustScore[user] = score;
+    }
+
+    function retrn(uint256 postId) external {
+        _logRetrn(msg.sender, bytes32(postId));
+    }
 
     function logRetrn(address user, bytes32 postHash) external {
+        _logRetrn(user, postHash);
+    }
+
+    function _logRetrn(address user, bytes32 postHash) internal {
         uint256 score = trustScore[user];
         uint256 multiplier = getMultiplier(score);
         emit WeightedRetrn(user, postHash, multiplier);
         emit RetrnLogged(user, postHash);
+        uint256 id = uint256(postHash);
+        postWeight[id] += multiplier;
+        if (!seen[id]) {
+            seen[id] = true;
+            posts.push(id);
+        }
+    }
+
+    function getPostCount() external view returns (uint256) {
+        return posts.length;
+    }
+
+    function getPostAt(uint256 index) external view returns (uint256) {
+        return posts[index];
     }
 
     function getMultiplier(uint256 score) internal pure returns (uint256) {

--- a/ado-core/test/RetrnReward.test.ts
+++ b/ado-core/test/RetrnReward.test.ts
@@ -1,0 +1,47 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+
+describe("Retrn Reward Flow", function () {
+  let oracle: any, retrn: any, lotto: any;
+  let userLowTrust: any, userHighTrust: any, posterA: any, posterB: any;
+
+  beforeEach(async () => {
+    [posterA, posterB, userLowTrust, userHighTrust] = await ethers.getSigners();
+
+    const Oracle = await ethers.getContractFactory("TRNUsageOracle");
+    oracle = await Oracle.deploy();
+
+    const RetrnIndex = await ethers.getContractFactory("RetrnIndex");
+    retrn = await RetrnIndex.deploy();
+
+    const Lotto = await ethers.getContractFactory("LottoModule");
+    lotto = await Lotto.deploy(retrn.target, oracle.target);
+
+    await lotto.setPoster(1, posterA.address);
+    await lotto.setPoster(2, posterB.address);
+
+    // Set trust scores manually for test
+    await retrn.setTrustScore(userLowTrust.address, 10); // low
+    await retrn.setTrustScore(userHighTrust.address, 90); // high
+  });
+
+  it("should reward higher-trust retrns more", async () => {
+    // Both posts get 3 retrns
+    await retrn.connect(userLowTrust).retrn(1); // post A
+    await retrn.connect(userLowTrust).retrn(1);
+    await retrn.connect(userLowTrust).retrn(1);
+
+    await retrn.connect(userHighTrust).retrn(2); // post B
+    await retrn.connect(userHighTrust).retrn(2);
+    await retrn.connect(userHighTrust).retrn(2);
+
+    // Trigger lotto payout
+    await lotto.triggerPayout();
+
+    const rewardA = await oracle.earnedTRN(posterA.address);
+    const rewardB = await oracle.earnedTRN(posterB.address);
+
+    expect(rewardB).to.be.gt(rewardA);
+  });
+});
+


### PR DESCRIPTION
## Summary
- expand `RetrnIndex` with trust tracking, post weights and owner controls
- implement new `LottoModule` contract rewarding top posts
- add integration test for retrn reward flow

## Testing
- `npm ci`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_68558178cebc833381529762be172e37