### PR TITLE
Add earnings tracking and dashboard link

### DIFF
--- a/thisrightnow/src/pages/dashboard.tsx
+++ b/thisrightnow/src/pages/dashboard.tsx
@@ -174,6 +174,14 @@ export default function Dashboard() {
 
   return (
     <div className="p-6 space-y-4">
+      <nav className="mb-4 space-x-4">
+        <a href="/dashboard" className="text-blue-600 underline">
+          Dashboard
+        </a>
+        <a href="/earnings" className="text-blue-600 underline">
+          Earnings
+        </a>
+      </nav>
       <h1 className="text-2xl font-bold">TRN Earnings Dashboard</h1>
       <div className="text-sm">
         <strong>Top Retrned Posts (trust-weighted):</strong>

--- a/thisrightnow/src/pages/earnings.tsx
+++ b/thisrightnow/src/pages/earnings.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { formatEther } from "viem";
+import { useAccount } from "wagmi";
+import { loadContract } from "@/utils/contract";
+import { ethers } from "ethers";
+import OracleABI from "@/abi/TRNUsageOracle.json";
+
+const ORACLE_ADDRESS = "0xORACLE_ADDRESS_HERE";
+
+export default function EarningsPage() {
+  const { address } = useAccount();
+  const [earnings, setEarnings] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (!address) return;
+
+    const fetchEarnings = async () => {
+      const provider = new ethers.BrowserProvider((window as any).ethereum);
+      const oracle = loadContract(ORACLE_ADDRESS, OracleABI as any, provider);
+      const data = await oracle.getEarnings(address);
+      setEarnings(data);
+    };
+
+    fetchEarnings();
+  }, [address]);
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Your Earnings</h1>
+      <table className="w-full text-left border-collapse">
+        <thead>
+          <tr>
+            <th>Post ID</th>
+            <th>Source</th>
+            <th>Amount (TRN)</th>
+            <th>Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {earnings.map((e, i) => (
+            <tr key={i}>
+              <td>{e.postId.toString()}</td>
+              <td>{e.source}</td>
+              <td>{formatEther(e.amount)}</td>
+              <td>{new Date(Number(e.timestamp) * 1000).toLocaleDateString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend `TRNUsageOracle` with an `Earning` struct and recording helpers
- expose recorded earnings to users
- new earnings page for dashboard
- link earnings page from dashboard nav

## Testing
- `npx hardhat test` *(fails: hardhat package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6855a1a8ce088333a6b079d4b813c257