### PR TITLE
Add post feed scaffold

### DIFF
--- a/thisrightnow/src/abi/BoostingModule.json
+++ b/thisrightnow/src/abi/BoostingModule.json
@@ -1,0 +1,12 @@
+[
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "postHash", "type": "bytes32" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "startBoost",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/abi/RetrnIndex.json
+++ b/thisrightnow/src/abi/RetrnIndex.json
@@ -1,0 +1,12 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "bytes32", "name": "postHash", "type": "bytes32" }
+    ],
+    "name": "logRetrn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/abi/ViewIndex.json
+++ b/thisrightnow/src/abi/ViewIndex.json
@@ -1,0 +1,12 @@
+[
+  {
+    "inputs": [
+      { "internalType": "string", "name": "ipfsHash", "type": "string" },
+      { "internalType": "string", "name": "category", "type": "string" }
+    ],
+    "name": "registerPost",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/components/CreatePost.tsx
+++ b/thisrightnow/src/components/CreatePost.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { submitPost } from "@/utils/submitPost";
+
+export default function CreatePost({ onPostCreated }: { onPostCreated: (post: any) => void }) {
+  const [text, setText] = useState("");
+  const [category, setCategory] = useState("general");
+
+  const handleSubmit = async () => {
+    const hash = await submitPost(text, category);
+    onPostCreated({ text, category, hash });
+    setText("");
+  };
+
+  return (
+    <div className="border p-4 rounded mb-4">
+      <textarea
+        className="w-full p-2 border rounded"
+        rows={3}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="What's happening?"
+      />
+      <div className="flex gap-2 mt-2">
+        <select value={category} onChange={(e) => setCategory(e.target.value)}>
+          <option value="general">General</option>
+          <option value="politics">Politics</option>
+          <option value="news">News</option>
+          <option value="nsfw">NSFW</option>
+        </select>
+        <button onClick={handleSubmit} className="bg-blue-600 text-white px-4 py-1 rounded">
+          Post
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/thisrightnow/src/components/PostCard.tsx
+++ b/thisrightnow/src/components/PostCard.tsx
@@ -1,0 +1,56 @@
+import { ethers } from "ethers";
+import { useAccount } from "wagmi";
+import { loadContract } from "@/utils/contract";
+import BurnRegistryABI from "@/abi/BurnRegistry.json";
+import RetrnIndexABI from "@/abi/RetrnIndex.json";
+import BoostingABI from "@/abi/BoostingModule.json";
+
+const BURN_REGISTRY = import.meta.env.VITE_BURN_REGISTRY;
+const RETRN_INDEX = import.meta.env.VITE_RETRN_INDEX;
+const BOOST_MODULE = import.meta.env.VITE_BOOST_MODULE;
+
+export default function PostCard({ post }: { post: any }) {
+  const { address } = useAccount();
+
+  async function bless() {
+    alert(`🙏 Blessed ${post.hash}`);
+  }
+
+  async function burn() {
+    const provider = new ethers.BrowserProvider((window as any).ethereum);
+    const signer = await provider.getSigner();
+    const burner = await loadContract(BURN_REGISTRY, BurnRegistryABI as any, signer);
+    await burner.burnPost(post.hash, "User burn");
+    alert("Burn transaction sent");
+  }
+
+  async function retrn() {
+    const provider = new ethers.BrowserProvider((window as any).ethereum);
+    const signer = await provider.getSigner();
+    const retrn = await loadContract(RETRN_INDEX, RetrnIndexABI as any, signer);
+    await retrn.logRetrn(address, post.hash);
+    alert("Retrn submitted");
+  }
+
+  async function boost() {
+    const provider = new ethers.BrowserProvider((window as any).ethereum);
+    const signer = await provider.getSigner();
+    const boost = await loadContract(BOOST_MODULE, BoostingABI as any, signer);
+    await boost.startBoost(post.hash, 100);
+    alert("Boost started");
+  }
+
+  return (
+    <div className="border p-4 rounded mb-4">
+      <p>{post.text}</p>
+      <div className="text-sm text-gray-500">{post.category}</div>
+      <div className="text-sm text-gray-500">{post.creator || post.address}</div>
+      <div className="flex gap-2 mt-2">
+        <button onClick={bless} className="px-2 py-1 bg-green-600 text-white rounded">Bless</button>
+        <button onClick={burn} className="px-2 py-1 bg-red-600 text-white rounded">Burn</button>
+        <button onClick={retrn} className="px-2 py-1 bg-yellow-600 text-white rounded">Retrn</button>
+        <button onClick={boost} className="px-2 py-1 bg-blue-600 text-white rounded">Boost</button>
+      </div>
+    </div>
+  );
+}

--- a/thisrightnow/src/components/PostFeed.tsx
+++ b/thisrightnow/src/components/PostFeed.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+import PostCard from "./PostCard";
+import CreatePost from "./CreatePost";
+
+export default function PostFeed() {
+  const [posts, setPosts] = useState<any[]>([]);
+
+  const handleNewPost = (post: any) => {
+    setPosts([post, ...posts]);
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <CreatePost onPostCreated={handleNewPost} />
+      {posts.map((p, i) => (
+        <PostCard key={i} post={p} />
+      ))}
+    </div>
+  );
+}

--- a/thisrightnow/src/pages/index.tsx
+++ b/thisrightnow/src/pages/index.tsx
@@ -1,0 +1,5 @@
+import PostFeed from "@/components/PostFeed";
+
+export default function HomePage() {
+  return <PostFeed />;
+}

--- a/thisrightnow/src/utils/ipfs.ts
+++ b/thisrightnow/src/utils/ipfs.ts
@@ -1,0 +1,10 @@
+export async function uploadToIPFS(data: any) {
+  const res = await fetch("https://ipfs.io/api/v0/add?pin=true", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+
+  const result = await res.json();
+  return result.Hash || result.cid || "";
+}

--- a/thisrightnow/src/utils/submitPost.ts
+++ b/thisrightnow/src/utils/submitPost.ts
@@ -1,0 +1,17 @@
+import { ethers } from "ethers";
+import { uploadToIPFS } from "./ipfs";
+import { loadContract } from "./contract";
+import ViewIndexABI from "@/abi/ViewIndex.json";
+
+const VIEW_INDEX = import.meta.env.VITE_VIEW_INDEX;
+
+export async function submitPost(content: string, category: string) {
+  const ipfsHash = await uploadToIPFS({ content, category, timestamp: Date.now() });
+
+  const provider = new ethers.BrowserProvider((window as any).ethereum);
+  const signer = await provider.getSigner();
+  const contract = loadContract(VIEW_INDEX, ViewIndexABI as any, signer);
+  await contract.registerPost(ipfsHash, category);
+
+  return ipfsHash;
+}


### PR DESCRIPTION
## Summary
- scaffold post creation and feed components
- add onchain interaction placeholders via PostCard
- implement `submitPost` util and IPFS helper
- create minimal ABIs for new utilities
- route home page to post feed

## Testing
- `npm test` *(fails: hardhat not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855aad56e20833390e293d0891ee65f