### PR TITLE
Warn on GeoOracle bans when creating posts

### DIFF
--- a/thisrightnow/src/components/CreatePost.tsx
+++ b/thisrightnow/src/components/CreatePost.tsx
@@ -1,9 +1,21 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { submitPost } from "@/utils/submitPost";
+import { getBannedCategories } from "@/utils/geoOracle";
 
 export default function CreatePost({ onPostCreated }: { onPostCreated: (post: any) => void }) {
   const [text, setText] = useState("");
   const [category, setCategory] = useState("general");
+  const [bannedCategories, setBannedCategories] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchRules = async () => {
+      const bans = await getBannedCategories("FR"); // TODO: derive from IP
+      setBannedCategories(bans);
+    };
+    fetchRules();
+  }, []);
+
+  const isBanned = bannedCategories.includes(category);
 
   const handleSubmit = async () => {
     const hash = await submitPost(text, category);
@@ -20,7 +32,7 @@ export default function CreatePost({ onPostCreated }: { onPostCreated: (post: an
         onChange={(e) => setText(e.target.value)}
         placeholder="What's happening?"
       />
-      <div className="flex gap-2 mt-2">
+      <div className="flex gap-2 mt-2 items-center">
         <select value={category} onChange={(e) => setCategory(e.target.value)}>
           <option value="general">General</option>
           <option value="politics">Politics</option>
@@ -30,6 +42,7 @@ export default function CreatePost({ onPostCreated }: { onPostCreated: (post: an
         <button onClick={handleSubmit} className="bg-blue-600 text-white px-4 py-1 rounded">
           Post
         </button>
+        {isBanned && <span className="text-red-500 text-sm">⚠️ Hidden in your country</span>}
       </div>
     </div>
   );

--- a/thisrightnow/src/utils/geoOracle.ts
+++ b/thisrightnow/src/utils/geoOracle.ts
@@ -1,0 +1,20 @@
+import { ethers } from "ethers";
+import { loadContract } from "./contract";
+import RulesetABI from "@/abi/CountryRulesetManager.json";
+
+const CONTRACT_ADDRESS = import.meta.env.VITE_RULESET_MANAGER;
+
+// In production, replace this with IP-derived country codes
+export async function getBannedCategories(countryCode: string): Promise<string[]> {
+  const provider = new ethers.BrowserProvider((window as any).ethereum);
+  const contract = loadContract(CONTRACT_ADDRESS, RulesetABI as any, provider);
+  const categories = ["general", "politics", "news", "nsfw"];
+
+  const results = await Promise.all(
+    categories.map((cat) =>
+      contract.isCategoryBanned(countryCode, cat).then((banned: boolean) => (banned ? cat : null))
+    )
+  );
+
+  return results.filter((c): c is string => c !== null);
+}


### PR DESCRIPTION
## Summary
- show banned category warning in the CreatePost flow
- add geoOracle helper for checking banned categories
- install hardhat deps and run tests

## Testing
- `npm --prefix ado-core test`

------
https://chatgpt.com/codex/tasks/task_e_6855ad7dacd48333ab4c3919256996f3